### PR TITLE
artifact tag from input/ref_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
       tag:
         description: 'Tag version'
         required: true
-        default: 'v0.0.1'
 
 env:
   NODE_VERSION: 20


### PR DESCRIPTION
## Details

Fixes a bug that was using full ref for artifact tags , changed it to either use input `tag` or `ref_name`