### PR TITLE
keep minimal params for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,5 @@ jobs:
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
         with:
           prerelease: true
-
           tag_name: ${{ env.ASSET_RELEASE_TAG_VERSION }}
           files: dist/wallet-generator.js


### PR DESCRIPTION
## Details

Remove optional params in release action to prevent modifying name and body of the release 